### PR TITLE
Updated Taggify.js to version 1.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "jquery": "^3.2.1",
     "alloyeditor": "^1.4",
     "flatpickr": "^4.0.7",
-    "taggify": "^1.0.0"
+    "taggify": "^1.2.1"
   }
 }


### PR DESCRIPTION
Bumped required Taggify version to 1.2.1

It contains fixes for:
- handling blur event on taggify inputs,
- displaying labels and tags when required,
- updating list of tags from external source.