### PR TITLE
Updated prepare_release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 package-lock.json
 yarn.lock
+node_modules/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 To prepare a tag for release you have to run the following command from the root directory of the bundle:
 
 ```
-sh bin/prepare_release.sh -v 1.0.0
+sh bin/prepare_release.sh -v 1.0.0 -b master
 ```
 
-The `1.0.0` stands for a version tag number that will be released.
+Options:
+1. -v : tag that will be released
+1. -b : branch which will be used to create the tag
+
+If you are tagging for eZPlatform 2.5.x LTS you should use the 4.x branch.

--- a/bin/prepare_release.sh
+++ b/bin/prepare_release.sh
@@ -9,14 +9,17 @@ print_usage()
     echo "This script MUST be run from the bundle root directory. It will create"
     echo "a tag but this tag will NOT be pushed"
     echo ""
-    echo "Usage: $1 -v <version>"
-    echo "-v version : where version will be used to create the tag"
+    echo "Usage: $1 -v <version> -b <branch>"
+    echo "-v : where version will be used to create the tag"
+    echo "-b : branch which will be used to create the tag"
 }
 
 VERSION=""
-while getopts "hv:" opt ; do
+BRANCH=""
+while getopts ":h:v:b:" opt ; do
     case $opt in
         v ) VERSION=$OPTARG ;;
+        b ) BRANCH=$OPTARG ;;
         h ) print_usage "$0"
             exit 0 ;;
         * ) print_usage "$0"
@@ -24,6 +27,7 @@ while getopts "hv:" opt ; do
     esac
 done
 
+[ -z "$BRANCH" ] && print_usage "$0" && exit 2
 [ -z "$VERSION" ] && print_usage "$0" && exit 2
 
 check_command()
@@ -72,9 +76,9 @@ CURRENT_BRANCH=`git branch | grep '*' | cut -d ' ' -f 2`
 TMP_BRANCH="version_$VERSION"
 TAG="v$VERSION"
 
-echo "# Switching to master and updating"
-git checkout -q master > /dev/null && git pull > /dev/null
-check_process "switch to master"
+echo "# Switching to $BRANCH and updating"
+git checkout -q $BRANCH > /dev/null && git pull > /dev/null
+check_process "switch to $BRANCH"
 
 echo "# Removing the assets"
 [ ! -d "$VENDOR_DIR" ] && mkdir -p $VENDOR_DIR


### PR DESCRIPTION
**Description**
When the bundle was updated to Symfony4 we cannot tag from the master for 2.5 LTS anymore. 

I created a stable branch for 4.0 (https://github.com/ezsystems/ezplatform-admin-ui-assets/tree/4.0) of this package. This branch will be used to create tags for eZPlatform 2.5.x.

Also I updated the `prepare_release.sh` to be able select a branch which will be used to create tag.

