### PR TITLE
Update moment timezone dependecy in order to avoid security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "jquery": "^3.5.1",
         "js-md5": "0.7.3",
         "leaflet": "^1.7.1",
-        "moment-timezone": "^0.5.32",
+        "moment-timezone": "^0.5.43",
         "popper.js": "^1.16.1",
         "prop-types": "^15.7.2",
         "react": "^16.14.0",


### PR DESCRIPTION
Many dependencies are tagged as vulnerable, but this PR only solves the minor version upgrade of Moment Timezone library in order to avoid the vulnerability solved in moment `2.29.2` (https://github.com/moment/moment/security/advisories/GHSA-8hfj-j24r-96c4)

Moment-Timezone solved the issue in its [0.5.41 release](https://github.com/moment/moment-timezone/releases/tag/0.5.41), but the PR defines `0.5.43` since it is the latest stable version with no vulnerabilities.